### PR TITLE
fix: added hbm2ddl.auto:create to test

### DIFF
--- a/src/test/java/com/liebniz/association/BookAuthorTest.java
+++ b/src/test/java/com/liebniz/association/BookAuthorTest.java
@@ -36,6 +36,7 @@ public class BookAuthorTest {
     @Test
     void testFindBookAuthorAssociation() {
         CustomPersistenceUnitInfo unitInfo = new CustomPersistenceUnitInfo("test");
+        unitInfo.setProperties("hibernate.hbm2ddl.auto", "create");
 
         try (CustomEntityManagerFactory customEmf = new CustomEntityManagerFactory(unitInfo)) {
 


### PR DESCRIPTION
Test failed due to the @BeforeAll persistence of 3 Book objects, which messed up the test. 

Adding hibernate.hbm2ddl.auto:create to props have these 3 entries removed from the database, and the test can be performed the way it was intended to.