### PR TITLE
fix: testFindBookAuthorAssociation throws

### DIFF
--- a/src/test/java/com/liebniz/association/BookAuthorTest.java
+++ b/src/test/java/com/liebniz/association/BookAuthorTest.java
@@ -36,7 +36,7 @@ public class BookAuthorTest {
     @Test
     void testFindBookAuthorAssociation() {
         CustomPersistenceUnitInfo unitInfo = new CustomPersistenceUnitInfo("test");
-        unitInfo.setProperties("hibernate.hbm2ddl.auto", "create");
+//        unitInfo.setProperties("hibernate.hbm2ddl.auto", "create");
 
         try (CustomEntityManagerFactory customEmf = new CustomEntityManagerFactory(unitInfo)) {
 


### PR DESCRIPTION
For some reason, testFinsBookAuthorAssociation throws exceptions when run. A quick solution to this is to comment out the props set to "hibernate.hbm2ddl.autp":"create".

This problem has to be investigated further.